### PR TITLE
2.0 Tools

### DIFF
--- a/tat/Dockerfile
+++ b/tat/Dockerfile
@@ -1,8 +1,10 @@
-FROM tomcat:9.0.63-jdk11
+FROM tomcat:9.0.73-jdk11
+RUN apt-get update && apt-get upgrade -y && apt-get install -y unzip
 COPY tomcat-config.xml /usr/local/tomcat/conf/server.xml
-ADD https://trustmarkinitiative.org/software/tat-1.4.war /tmp/tat.war
+ADD https://trustmarkinitiative.org/software/tat-2.0.war /tmp/tat.war
 RUN unzip -d /usr/local/tomcat/webapps/tat /tmp/tat.war
-COPY tat_config.properties /usr/local/tomcat/webapps/tat/WEB-INF/classes
+COPY tat_config.properties  /usr/local/tomcat/webapps/tat/WEB-INF/classes
+COPY application.properties /usr/local/tomcat/webapps/tat/WEB-INF/classes
 COPY ./images/banner.png /usr/local/tomcat/webapps/tat/assets/tmi-header-56eb1cb69ffde28907e0a78527bbd88d.png
 COPY ./images/favicon.ico /usr/local/tomcat/webapps/ROOT/
 COPY ./images/favicon.ico /usr/local/tomcat/webapps/tat/

--- a/tat/application.properties
+++ b/tat/application.properties
@@ -1,0 +1,10 @@
+#The Client ID must match the client ID defined in Keycloak
+spring.security.oauth2.client.registration.keycloak.client-id=tat
+
+#The issuer URI must be the URL of the Trustmark realm in your organization's Keycloak deploy
+spring.security.oauth2.client.provider.keycloak.issuer-uri=https://[KEYCLOAK URL]/auth/realms/trustmark
+
+#Both URIs must be set to the Keycloak used to protect this TAT's API
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://[KEYCLOAK URL]/auth/realms/trustmark/protocol/openid-connect/certs
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://[KEYCLOAK URL]/auth/realms/trustmark
+

--- a/tat/tat_config.properties
+++ b/tat/tat_config.properties
@@ -11,6 +11,14 @@ tf.tool.name = Trustmark Assessment Tool
 tf.base.url = http://localhost:8081/tat
 tf.public.api = /public/trustmarks
 
+#=======================================================================================================================
+# API Protection Configuration
+#=======================================================================================================================
+
+#Flag to enable/disable api protection
+api_client_authorization_required=false
+
+
 #-----------------------------------------------------------------------------------------------------------------------
 #  Configure the system to send email.
 #   - This is not needed for sandbox configurations, but is recommended for any production deployment.
@@ -64,14 +72,6 @@ org.1.identifier=ORG
 org.1.uri=https://yourorg.org/
 org.1.contact=email@address.org
 org.1.isTrustmarkProvider=1
-
-user.count=1
-user.1.username=admin
-user.1.password=ADMIN_PASSWORD
-user.1.contact=email@address.org
-user.1.org=ORG
-user.1.roles=ROLE_USER,ROLE_ADMIN
-
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Default Trustmark Metadata Values

--- a/tbr/Dockerfile
+++ b/tbr/Dockerfile
@@ -1,8 +1,10 @@
-FROM tomcat:9.0.63-jdk11
+FROM tomcat:9.0.73-jdk11
+RUN apt-get update && apt-get upgrade -y && apt-get install -y unzip
 COPY tomcat-config.xml /usr/local/tomcat/conf/server.xml
-ADD https://trustmarkinitiative.org/software/tbr-1.3.war /tmp/tbr.war
+ADD https://trustmarkinitiative.org/software/tbr-2.0.war /tmp/tbr.war
 RUN unzip -d /usr/local/tomcat/webapps/tbr /tmp/tbr.war
-COPY tbr_config.properties /usr/local/tomcat/webapps/tbr/WEB-INF/classes
+COPY tbr_config.properties  /usr/local/tomcat/webapps/tbr/WEB-INF/classes
+COPY application.properties /usr/local/tomcat/webapps/tbr/WEB-INF/classes
 COPY ./images/banner.png /usr/local/tomcat/webapps/tbr/assets/tmi-header-6a00aed2b9e1b873d00c5f0c9bbbd7d3.png
 COPY ./images/favicon.ico /usr/local/tomcat/webapps/ROOT/
 COPY ./images/favicon.ico /usr/local/tomcat/webapps/tbr/

--- a/tbr/application.properties
+++ b/tbr/application.properties
@@ -1,0 +1,10 @@
+#The Client ID must match the client ID defined in Keycloak
+spring.security.oauth2.client.registration.keycloak.client-id=tbr
+
+#The issuer URI must be the URL of the Trustmark realm in your organization's Keycloak deploy
+spring.security.oauth2.client.provider.keycloak.issuer-uri=https://[KEYCLOAK URL]/auth/realms/trustmark
+
+#Both URIs must be set to the Keycloak used to protect this TBR's API
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://[KEYCLOAK URL]/auth/realms/trustmark/protocol/openid-connect/certs
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://[KEYCLOAK URL]/auth/realms/trustmark
+

--- a/tbr/tbr_config.properties
+++ b/tbr/tbr_config.properties
@@ -4,12 +4,6 @@
 #  The first value in the list will be used as the default base URI during bulk creation of artifacts.
 tf.base.url = http://localhost:8082/tbr
 
-## the default user to login to the system for the first time
-tbr.org.user = email@yourdomain.tld
-
-## the default password on first login, note this can be changed in the tool under Configuration
-tbr.org.pswd = [DEFAULT_PW_HERE]
-
 #Test URL, but not appropriate for production
 registry.url=https://tpat.trustmarkinitiative.org/test-artifacts/
 
@@ -25,8 +19,12 @@ tbr.org.title = Trustmark Binding Registry
 ##  identifying url for the tool
 tbr.org.identifier = https://tbr.trustmarkinitiative.org/
 
-## the default user name on first time login
-tbr.org.username = Administrator
+#=======================================================================================================================
+# API Protection Configuration
+#=======================================================================================================================
+#Flag to enable/disable api protection
+api_client_authorization_required=false
+
 
 # Default Organization Information
 #  This organization is the "owner" of this TFAM instance.

--- a/tpat/Dockerfile
+++ b/tpat/Dockerfile
@@ -1,8 +1,10 @@
-FROM tomcat:9.0.63-jdk11
+FROM tomcat:9.0.73-jdk11
+RUN apt-get update && apt-get upgrade -y && apt-get install -y unzip
 COPY tomcat-config.xml /usr/local/tomcat/conf/server.xml
-ADD https://trustmarkinitiative.org/software/tpat-1.5.war /tmp/tpat.war
+ADD https://trustmarkinitiative.org/software/tpat-2.0.war /tmp/tpat.war
 RUN unzip -d /usr/local/tomcat/webapps/tpat /tmp/tpat.war
 COPY tpat_config.properties /usr/local/tomcat/webapps/tpat/WEB-INF/classes
+COPY application.properties /usr/local/tomcat/webapps/tpat/WEB-INF/classes
 COPY ./images/banner.png /usr/local/tomcat/webapps/tpat/assets/tmi-header-56eb1cb69ffde28907e0a78527bbd88d.png
 COPY ./images/banner.png /usr/local/tomcat/webapps/tpat/assets/tmi-header-6c6f1a43dfc14aaab266274bdaac780b.png
 COPY ./images/favicon.ico /usr/local/tomcat/webapps/ROOT/

--- a/tpat/application.properties
+++ b/tpat/application.properties
@@ -1,0 +1,6 @@
+#The Client ID must match the client ID defined in Keycloak
+spring.security.oauth2.client.registration.keycloak.client-id=tpat
+
+#The issuer URI must be the URL of the Trustmark realm in your organization's Keycloak deploy
+spring.security.oauth2.client.provider.keycloak.issuer-uri=https://[KEYCLOAK URL]/gauth/realms/trustmark
+

--- a/tpat/tpat_config.properties
+++ b/tpat/tpat_config.properties
@@ -7,15 +7,6 @@
 #  The path part of this URL must match the path within the file 'Dockerfile':
 tf.base.url = http://localhost:8080/tpat/|http://tpat:8080/tpat/
 
-## The default user to login to the system
-tf.org.user = admin
-
-## The display name of the user
-tf.org.username = Admin User
-
-## the default password on first login, note this can be changed in the tool under Configuration
-tf.org.pswd = ADMIN_PASSWORD_HERE
-
 ##  The title of the tool in both the navigation bar (Probably good to make it [Org Abbreviation] TPAT)
 tf.org.tooltitle = Trust Policy Authoring Tool
 

--- a/trpt/Dockerfile
+++ b/trpt/Dockerfile
@@ -1,8 +1,10 @@
-FROM tomcat:9.0.63-jdk11
+FROM tomcat:9.0.73-jdk11
+RUN apt-get update && apt-get upgrade -y && apt-get install -y unzip
 COPY tomcat-config.xml /usr/local/tomcat/conf/server.xml
-ADD https://trustmarkinitiative.org/software/trpt-1.2.war /tmp/trpt.war
+ADD https://trustmarkinitiative.org/software/trpt-2.0.war /tmp/trpt.war
 RUN unzip -d /usr/local/tomcat/webapps/trpt /tmp/trpt.war
-COPY trpt.properties /usr/local/tomcat/webapps/trpt/WEB-INF/classes
+COPY trpt.properties        /usr/local/tomcat/webapps/trpt/WEB-INF/classes
+COPY application.properties /usr/local/tomcat/webapps/trpt/WEB-INF/classes
 COPY ./images/banner.png /usr/local/tomcat/webapps/trpt/assets/tmi-header-6a00aed2b9e1b873d00c5f0c9bbbd7d3.png
 COPY ./images/favicon.ico /usr/local/tomcat/webapps/ROOT/
 COPY ./images/favicon.ico /usr/local/tomcat/webapps/trpt/

--- a/trpt/application.properties
+++ b/trpt/application.properties
@@ -1,0 +1,6 @@
+#The Client ID must match the client ID defined in Keycloak
+spring.security.oauth2.client.registration.keycloak.client-id=trpt
+
+#The issuer URI must be the URL of the Trustmark realm in your organization's Keycloak deploy
+spring.security.oauth2.client.provider.keycloak.issuer-uri=https://[KEYCLOAK URL]/auth/realms/trustmark
+

--- a/trpt/trpt.properties
+++ b/trpt/trpt.properties
@@ -8,19 +8,6 @@ server.url=http://localhost:8083/trpt/
 # Title for the site, useful to customize to something short for bookmarks/tabs.
 server.title=Trustmark Relying Party Tool
 
-# Default User - If you intend to use this account beyond creating an account with the 
-# tool, the username should be a valid email address.
-user.username=admin@trustmarkinitiative.org
-user.password=ADMIN_PASSWORD
-user.nameGiven=FirstName
-user.nameFamily=LastName
-user.telephone=555-555-2345
-user.userEnabled=true
-user.userLocked=false
-user.userExpired=false
-user.passwordExpired=false
-role.name=ROLE_ADMINISTRATOR
-
 # Your organization
 organization.name=Trustmark Initiative
 organization.uri=https://trustmarkinitiative.org/


### PR DESCRIPTION
For experimenting with the tools on a local device, the 1.* tools are still recommended, as the complexity of SSO integration makes using the tools on a localhost not typically worth the time.
